### PR TITLE
add solar-staff.com

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -181,5 +181,8 @@
     },
     {
         "page": "http://saratov.gov.ru"
+    },
+    {
+        "page": "https://solar-staff.com"
     }
 ]


### PR DESCRIPTION
This company provides service to avoid anti-russian SWIFT sanctions [1].
It should be shut down.

[1]
Западные страны договорились отключить от SWIFT ряд российских банков. Фактически, это значит, что международные переводы для них будут невозможны. Сейчас отключение распространяется только на банки, попавшие под санкции, но «при необходимости» эта мера затронет «и другие российские банки», — сообщила глава Еврокомиссии Урсула фон дер Ляйен. Без SWIFT банки не смогут обмениваться платёжными документами, поручениями, подтверждать сделки. Альтернативой могут стать e-mail, бумажные платёжные поручения, факс, телефонные звонки — но это будет стоить значительно дороже и займёт больше времени.

Для российского бизнеса, работающего на международный рынок, ситуация непростая, но не безвыходная. Сервис безопасных сделок Solar Staff по-прежнему помогает рассчитываться с любыми специалистами из любых стран — дизайнерами, блогерами, менеджерами, программистами и другими.

Для тех компаний, которые ещё не работали с сервисом, действуют специальные условия — сниженная комиссия 6% на выплаты в течение следующих 3-х месяцев. Чтобы воспользоваться предложением, достаточно оставить заявку на сайте.

Solar Staff

Signed-off-by: Oleksandr Suvorov <cryosay@gmail.com>